### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [vger]
+    - documentation_targets: [vgerSwift]


### PR DESCRIPTION
I noticed that documentation generation fails with:

```
error: target 'vger' is not a Swift source module"
```